### PR TITLE
Legg til BigQuery Databasebruker

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -50,6 +50,8 @@ spec:
         databases:
           - name: sykepengesoknad-arkivering-oppgave-db
             envVarPrefix: DB
+            users:
+              - name: bigquery-dataprodukt
   accessPolicy:
     outbound:
       rules:

--- a/src/main/resources/db/migration/V5__grant_tilgang_til_BigQuery.sql
+++ b/src/main/resources/db/migration/V5__grant_tilgang_til_BigQuery.sql
@@ -1,0 +1,10 @@
+DO
+$$
+    BEGIN
+        IF EXISTS
+            (SELECT 1 FROM pg_user where usename = 'bigquery-dataprodukt')
+        THEN
+            GRANT SELECT ON oppgavestyring TO "bigquery-dataprodukt";
+        END IF;
+    END
+$$;

--- a/src/main/resources/db/migration/V6__plass_til_lengre_statusnavn.sql
+++ b/src/main/resources/db/migration/V6__plass_til_lengre_statusnavn.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppgavestyring
+ALTER COLUMN status TYPE varchar(50);

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>[%t, %d, %-5p, %C:%L, %X{Nav-Callid}] - %.-100000m%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="WARN">
+		<appender-ref ref="CONSOLE"/>
+	</root>
+
+	<logger name="no.nav.helse" level="DEBUG"/>
+	<logger name="org.springframework" level="INFO"/>
+</configuration>


### PR DESCRIPTION
- Legger til bruker provisjoner av Nais og gir brukeren tilgang til hente data fra `oppgavestyring`.
- Øker lengden på statuskolonnen i `oppgavestyring` da det vil komme statues som er lengre enn 20 tegn.
- Slår av JSON-logging når kjører tester.
