### PR TITLE
Ikke sjekk medlemskap vurdering når det ikke trengs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,36 @@ følger samme logikk som over.
 
 En del søknader har ikke spedisjon et forhold til, da setter vi timeout til 1 minutt slik at vi ikke venter for lenge på spedisjon.
 
+## Behandlingstype Medlemskap
+
+Når en sykepengesøknad mottas på Kafaka og feltet `medlemskapsvurdering` er satt, lagres verdien i databasen. Når det 
+eventuelt opprettes en Gosys-oppgave på den samme søknaden brukes verdien(e) til å avgjøre om oppgaven skal inneholde informasjon
+om bruker er medlems i folketrygden eller ikke, eller om dette må avklares. Følgende scenarios kan oppstå: 
+
+| Inngående Vurdering              | Endelig Vurdering           | Behandlingstype  | Gosys-oppgave                          |
+|----------------------------------|-----------------------------|------------------|----------------------------------------|
+| null (ingen inngående vurdering) | null (sjekker ikke)         | SYKEPENGER       | null (ingen informasjon)               |
+| UAVKLART (brukerspørsmål)        | UAVKLART                    | MEDLEMSKAP       | UAVKLART (uavklart-tekst + brukersvar) |
+| UAVKLART (brukerspørsmål)        | null (feil fra LovMe)       | MEDLEMSKAP       | UAVKLART (uavklart-tekst + brukersvar) |
+| UAVKLART (brukerspørsmål)        | NEI                         | MEDLEMSKAP       | NEI (nei-tekst + brukersvar)           |
+| NEI                              | null (sjekker ikke)         | MEDLEMSKAP       | NEI (nei-tekst)                        |
+| UAVKLART (brukerspørsmål)        | JA                          | SYKEPENGER       | null (ingen informasjon)               |
+| UAVKLART                         | null (sjekker ikke)         | SYKEPENGER       | null (ingen informasjon)               |
+| JA                               | null (sjekker ikke)         | SYKEPENGER       | null (ingen informasjon)               |
+                                  |
 
 ## Data
 Applikasjonen har en database i GCP. 
 
-Tabellen `INNSENDING` lenker sykepengesøknad id med journalpostid og oppgaveid. Det slettes ikke data fra tabellen.
+Tabellen `innsending` lenker sykepengesøknad id med journalpostid og oppgaveid. Det slettes ikke data fra tabellen.
 
-Tabellen `OPPGAVESTYRING` holder informasjon om en sykepengesøknad skal få sin oppgave oppretta i gosys eller om denne oppgaven blir behandlet i ny løsning.
+Tabellen `oppgavestyring` holder informasjon om en sykepengesøknad skal få sin oppgave oppretta i gosys eller om denne oppgaven blir behandlet i ny løsning.
 Det slettes ikke data fra tabellen. Dataene kopieres også nattlig over til et bigquery datasett.
 
 
 # Komme i gang
 
-Bygges med gradle. Standard spring boot oppsett.
+Bygges med gradle. Standard Spring Boot oppsett.
 
 ---
 

--- a/src/main/kotlin/no/nav/helse/flex/medlemskap/LovMeClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/medlemskap/LovMeClient.kt
@@ -50,12 +50,14 @@ class LovMeClient(
                     EndeligVurderingResponse::class.java,
                 )
 
-            return result.body ?: throw RuntimeException(
-                "LovMe returnerer ikke endelig medlemskap vurdering for " +
-                    "sykepengesoknadId: ${sykepengesoknad.id}",
-            )
+            return if (result.body != null) {
+                result.body
+            } else {
+                log.error("Mottok svar fra LovMe, men uten endelig medlemskapsvurdering for sykepengesoknadId: ${sykepengesoknad.id}.")
+                null
+            }
         } catch (e: Exception) {
-            log.warn("Fant ikke endelig medlemskap vurdering for sykepengesoknadId ${sykepengesoknad.id}", e)
+            log.error("Fant ikke endelig medlemskap vurdering for sykepengesoknadId ${sykepengesoknad.id}.", e)
             return null
         }
     }

--- a/src/main/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurdering.kt
+++ b/src/main/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurdering.kt
@@ -14,7 +14,7 @@ class MedlemskapVurdering(
     private val log = logger()
 
     fun oppdaterInngåendeMedlemskapVurdering(sykepengesoknad: Sykepengesoknad) {
-        if (!sykepengesoknad.skalGjøreMedlemskapVurering()) {
+        if (!sykepengesoknad.skalHaMedlemskapVurering()) {
             return
         }
         if (medlemskapVurderingRepository.findBySykepengesoknadId(sykepengesoknad.id) != null) {
@@ -38,31 +38,35 @@ class MedlemskapVurdering(
     }
 
     fun hentEndeligMedlemskapVurdering(sykepengesoknad: Sykepengesoknad): String? {
-        if (!sykepengesoknad.skalGjøreMedlemskapVurering()) {
+        if (!sykepengesoknad.skalHaMedlemskapVurering()) {
             return null
         }
 
         val tidligereVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(sykepengesoknad.id)
         if (tidligereVurdering == null) {
-            log.info("Søknad ${sykepengesoknad.id} er ikke medlemskap vurdert")
+            log.info("Søknad ${sykepengesoknad.id} har ikke inngående vurdering, så gjør ikke endelig vurdering.")
             return null
         }
+
+        // Returnerer endelig vurdering hvis den allerede finnes.
         if (tidligereVurdering.endeligVurdering != null) {
-            log.info("Søknad ${sykepengesoknad.id} er allerede medlemskap vurdert til ${tidligereVurdering.endeligVurdering}")
+            log.info("Søknad ${sykepengesoknad.id} har allerede endelig vurdering: ${tidligereVurdering.endeligVurdering}")
 
             if (medlemskapToggle.medlemskapToggleForBruker(sykepengesoknad.fnr)) {
                 return tidligereVurdering.endeligVurdering
             }
-
             return null
         }
 
+        // Gjør at vi lagrer "null" som endelig vurdering hvis kallet til LovMe feiler.
         val endeligVurdering = lovMeClient.hentEndeligMedlemskapVurdering(sykepengesoknad) ?: return null
+
         val oppdatertVurdering =
             tidligereVurdering.copy(
                 vurderingId = endeligVurdering.vurdering_id,
                 endeligVurdering = endeligVurdering.status.name,
             )
+
         medlemskapVurderingRepository.save(oppdatertVurdering)
 
         if (medlemskapToggle.medlemskapToggleForBruker(sykepengesoknad.fnr)) {
@@ -72,6 +76,10 @@ class MedlemskapVurdering(
         return null
     }
 
-    private fun Sykepengesoknad.skalGjøreMedlemskapVurering() =
-        soknadstype in listOf(Soknadstype.ARBEIDSTAKERE, Soknadstype.GRADERT_REISETILSKUDD)
+    private fun Sykepengesoknad.skalHaMedlemskapVurering() =
+        soknadstype in
+            listOf(
+                Soknadstype.ARBEIDSTAKERE,
+                Soknadstype.GRADERT_REISETILSKUDD,
+            )
 }

--- a/src/main/kotlin/no/nav/helse/flex/oppgave/BeskrivelseService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/oppgave/BeskrivelseService.kt
@@ -65,6 +65,7 @@ private fun Merknad.beskrivMerknad(): String {
         "UNDER_BEHANDLING" ->
             "OBS! Sykmeldingen er tilbakedatert. Tilbakedateringen var ikke behandlet når søknaden " +
                 "ble sendt. Sjekk gosys for resultat på tilbakedatering"
+
         else -> {
             log.warn("Ukjent merknadstype $type")
             "OBS! Sykmeldingen har en merknad $this"
@@ -140,19 +141,33 @@ private fun Soknad.beskrivFaktiskGradFrilansere(): String {
 }
 
 private fun Soknad.beskrivMedlemskapVurdering(): String {
-    if (medlemskapVurdering in listOf("UAVKLART", "NEI")) {
-        return """
+    return when (medlemskapVurdering) {
+        "UAVKLART" ->
+            """
             
             Om bruker er medlem i folketrygden eller ikke, kunne ikke avklares automatisk.
-            Medlemskap status: $medlemskapVurdering
+            Medlemskap status: UAVKLART
             
             Du må se på svarene til bruker.
             Informasjon om hva du skal gjøre finner du på Navet, se
             https://navno.sharepoint.com/sites/fag-og-ytelser-eos-lovvalg-medlemskap/SitePages/Hvordan-vurderer-jeg-lovvalg-og-medlemskap.aspx
             
             """.trimIndent()
+
+        "NEI" ->
+            """
+
+            Om bruker er medlem i folketrygden eller ikke er automatisk avklart.
+            Medlemskap status: NEI
+
+            Se på medlemskapsfanen i Gosys for å finne riktig periode.
+            Se på dokumentet i Gosys for å finne arbeidsgiver.
+            Se i Aa-registeret om bruker har samme arbeidsgiver som i vedtaket/A1 fra utlandet.
+            Hvis Ja: Bruker er ikke medlem. Hvis Nei: Kontakt bruker/arbeidsgiver for å avklare brukers situasjon.
+
+            """.trimIndent()
+        else -> ""
     }
-    return ""
 }
 
 private fun Soknad.beskrivInntektsopplysninger(): String {

--- a/src/main/kotlin/no/nav/helse/flex/service/BehandlingstemaOgType.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/BehandlingstemaOgType.kt
@@ -3,16 +3,16 @@ package no.nav.helse.flex.service
 import no.nav.helse.flex.domain.dto.Soknadstype
 import no.nav.helse.flex.domain.dto.Sykepengesoknad
 
-const val FORKORTET_VENTETID = "ae0247"
-const val TILBAKEDATERING = "ae0239"
-const val OVERGANGSSAK_FRA_SPEIL = "ab0455"
-const val UTLAND = "ae0106"
-const val MEDLEMSKAP = "ab0269"
-const val SYKEPENGER_UNDER_UTENLANDSOPPHOLD = "ab0314"
-const val ENKELTSTAENDE_BEHANDLINGSDAGER = "ab0351"
-const val SYKEPENGER_FOR_ARBEIDSLEDIG = "ab0426"
-const val REISETILSKUDD = "ab0237"
-const val SYKEPENGER = "ab0061"
+const val BEHANDLINGSTEMA_FORKORTET_VENTETID = "ae0247"
+const val BEHANDLINGSTEMA_TILBAKEDATERING = "ae0239"
+const val BEHANDLINGSTEMA_OVERGANGSSAK_FRA_SPEIL = "ab0455"
+const val BEHANDLINGSTEMA_UTLAND = "ae0106"
+const val BEHANDLINGSTEMA_MEDLEMSKAP = "ab0269"
+const val BEHANDLINGSTEMA_SYKEPENGER_UNDER_UTENLANDSOPPHOLD = "ab0314"
+const val BEHANDLINGSTEMA_ENKELTSTAENDE_BEHANDLINGSDAGER = "ab0351"
+const val BEHANDLINGSTEMA_SYKEPENGER_FOR_ARBEIDSLEDIG = "ab0426"
+const val BEHANDLINGSTEMA_REISETILSKUDD = "ab0237"
+const val BEHANDLINGSTEMA_SYKEPENGER = "ab0061"
 
 fun finnBehandlingstemaOgType(
     soknad: Sykepengesoknad,
@@ -21,27 +21,27 @@ fun finnBehandlingstemaOgType(
     medlemskapVurdering: String?,
 ): BehandlingstemaOgType {
     if (harRedusertVenteperiode) {
-        return behandlingstype(FORKORTET_VENTETID)
+        return behandlingstype(BEHANDLINGSTEMA_FORKORTET_VENTETID)
     }
     if (soknad.gjelderTilbakedatering()) {
-        return behandlingstype(TILBAKEDATERING)
+        return behandlingstype(BEHANDLINGSTEMA_TILBAKEDATERING)
     }
     if (speilRelatert) {
-        return behandlingstema(OVERGANGSSAK_FRA_SPEIL)
+        return behandlingstema(BEHANDLINGSTEMA_OVERGANGSSAK_FRA_SPEIL)
     }
     if (soknad.utenlandskSykmelding == true) {
-        return behandlingstype(UTLAND)
+        return behandlingstype(BEHANDLINGSTEMA_UTLAND)
     }
-    if (medlemskapVurdering in listOf("NEI", "UAVKLART")) {
-        return behandlingstema(MEDLEMSKAP)
+    if (medlemskapVurdering in listOf("UAVKLART", "NEI")) {
+        return behandlingstema(BEHANDLINGSTEMA_MEDLEMSKAP)
     }
     return behandlingstema(
         when (soknad.soknadstype) {
-            Soknadstype.OPPHOLD_UTLAND -> SYKEPENGER_UNDER_UTENLANDSOPPHOLD
-            Soknadstype.BEHANDLINGSDAGER -> ENKELTSTAENDE_BEHANDLINGSDAGER
-            Soknadstype.ARBEIDSLEDIG -> SYKEPENGER_FOR_ARBEIDSLEDIG
-            Soknadstype.REISETILSKUDD, Soknadstype.GRADERT_REISETILSKUDD -> REISETILSKUDD
-            else -> SYKEPENGER
+            Soknadstype.OPPHOLD_UTLAND -> BEHANDLINGSTEMA_SYKEPENGER_UNDER_UTENLANDSOPPHOLD
+            Soknadstype.BEHANDLINGSDAGER -> BEHANDLINGSTEMA_ENKELTSTAENDE_BEHANDLINGSDAGER
+            Soknadstype.ARBEIDSLEDIG -> BEHANDLINGSTEMA_SYKEPENGER_FOR_ARBEIDSLEDIG
+            Soknadstype.REISETILSKUDD, Soknadstype.GRADERT_REISETILSKUDD -> BEHANDLINGSTEMA_REISETILSKUDD
+            else -> BEHANDLINGSTEMA_SYKEPENGER
         },
     )
 }

--- a/src/main/kotlin/no/nav/helse/flex/service/SaksbehandlingsService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/SaksbehandlingsService.kt
@@ -190,20 +190,24 @@ class SaksbehandlingsService(
         return this.sporsmal.any { it.tag.startsWith("MEDLEMSKAP_") }
     }
 
-    // TODO: Denne må gjenskapes i tester, og den er vanskelig å lese.
     private fun hentEndeligMedlemskapVurdering(
         sykepengesoknad: Sykepengesoknad,
         inngaendeVurdering: String?,
     ): String? {
-        return if (inngaendeVurdering == "UAVKLART" && sykepengesoknad.harMedlemskapSporsmal()) {
-            // Returnerer UAVKLART hvis endeligVurdering er null er siden det kan skyldes at LovMe ikke har svart selv
-            // om vi vet at bruker HAR svart på medlemskapsspørsmål.
-            medlemskapVurdering.hentEndeligMedlemskapVurdering(sykepengesoknad) ?: "UAVKLART"
-        } else if (inngaendeVurdering == "NEI") {
-            // Returnerer NEI hvis inngående vurdering er NEI, siden vi da ikke spør om endelig vurdering.
-            "NEI"
-        } else {
-            null
+        return when (inngaendeVurdering) {
+            "UAVKLART" -> {
+                if (sykepengesoknad.harMedlemskapSporsmal()) {
+                    // Returnerer UAVKLART hvis endeligVurdering er null er siden det kan skyldes at LovMe ikke har
+                    // svart selv om vi vet at bruker har svart på medlemskapsspørsmål.
+                    medlemskapVurdering.hentEndeligMedlemskapVurdering(sykepengesoknad) ?: "UAVKLART"
+                } else {
+                    null
+                }
+            }
+            // Returnerer NEI so, endelig vurdring hvis inngående vurdering er NEI, siden vi da ikke spør om
+            // endelig vurdering, men NEI skal behandles som en medlemskapsoppgave.
+            "NEI" -> "NEI"
+            else -> null
         }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/service/SaksbehandlingsService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/SaksbehandlingsService.kt
@@ -12,6 +12,7 @@ import no.nav.helse.flex.domain.dto.Sykepengesoknad
 import no.nav.helse.flex.kafka.producer.RebehandleSykepengesoknadProducer
 import no.nav.helse.flex.logger
 import no.nav.helse.flex.medlemskap.MedlemskapVurdering
+import no.nav.helse.flex.medlemskap.MedlemskapVurderingRepository
 import no.nav.helse.flex.repository.InnsendingDbRecord
 import no.nav.helse.flex.repository.InnsendingRepository
 import no.nav.helse.flex.tilbakedaterte.OppgaverForTilbakedaterteDbRecord
@@ -33,6 +34,7 @@ class SaksbehandlingsService(
     private val identService: IdentService,
     private val pdlClient: PdlClient,
     private val medlemskapVurdering: MedlemskapVurdering,
+    private val medlemskapVurderingRepository: MedlemskapVurderingRepository,
 ) {
     private val log = logger()
 
@@ -54,9 +56,8 @@ class SaksbehandlingsService(
                     innsendingId!!,
                     soknad,
                 )
-            log.info("Journalført søknad: ${sykepengesoknad.id} med journalpostId: $jouralpostId")
+            log.info("Journalført søknad: ${sykepengesoknad.id} med journalpostId: $jouralpostId.")
         }
-
         medlemskapVurdering.oppdaterInngåendeMedlemskapVurdering(sykepengesoknad)
 
         return innsendingId!!
@@ -68,15 +69,19 @@ class SaksbehandlingsService(
         speilRelatert: Boolean = false,
     ) {
         val fnr = identService.hentFnrForAktorId(sykepengesoknad.aktorId)
-        val medlemskapVurdering = medlemskapVurdering.hentEndeligMedlemskapVurdering(sykepengesoknad)
-        val soknad = opprettSoknad(sykepengesoknad, fnr, medlemskapVurdering)
+        val endeligVurdering =
+            hentEndeligMedlemskapVurdering(
+                sykepengesoknad,
+                medlemskapVurderingRepository.findBySykepengesoknadId(sykepengesoknad.id)?.inngaendeVurdering,
+            )
+        val soknad = opprettSoknad(sykepengesoknad, fnr, endeligVurdering)
 
         val behandlingstemaOgType =
             finnBehandlingstemaOgType(
                 soknad = sykepengesoknad,
                 harRedusertVenteperiode = sykepengesoknad.harRedusertVenteperiode,
                 speilRelatert = speilRelatert,
-                medlemskapVurdering = medlemskapVurdering,
+                medlemskapVurdering = endeligVurdering,
             )
 
         val requestBody =
@@ -89,7 +94,7 @@ class SaksbehandlingsService(
         val oppgaveResponse = oppgaveClient.opprettOppgave(requestBody)
 
         innsendingRepository.updateOppgaveId(id = innsending.id!!, oppgaveId = oppgaveResponse.id.toString())
-        if (requestBody.behandlingstype == TILBAKEDATERING) {
+        if (requestBody.behandlingstype == BEHANDLINGSTEMA_TILBAKEDATERING) {
             oppgaverForTilbakedaterteRepository.save(
                 OppgaverForTilbakedaterteDbRecord(
                     sykepengesoknadUuid = sykepengesoknad.id,
@@ -179,5 +184,26 @@ class SaksbehandlingsService(
                 "Antall innsendinger hvor feil mot baksystemer gjorde at behandling ikke kunne fullføres.",
             ),
         ).increment()
+    }
+
+    private fun Sykepengesoknad.harMedlemskapSporsmal(): Boolean {
+        return this.sporsmal.any { it.tag.startsWith("MEDLEMSKAP_") }
+    }
+
+    // TODO: Denne må gjenskapes i tester, og den er vanskelig å lese.
+    private fun hentEndeligMedlemskapVurdering(
+        sykepengesoknad: Sykepengesoknad,
+        inngaendeVurdering: String?,
+    ): String? {
+        return if (inngaendeVurdering == "UAVKLART" && sykepengesoknad.harMedlemskapSporsmal()) {
+            // Returnerer UAVKLART hvis endeligVurdering er null er siden det kan skyldes at LovMe ikke har svart selv
+            // om vi vet at bruker HAR svart på medlemskapsspørsmål.
+            medlemskapVurdering.hentEndeligMedlemskapVurdering(sykepengesoknad) ?: "UAVKLART"
+        } else if (inngaendeVurdering == "NEI") {
+            // Returnerer NEI hvis inngående vurdering er NEI, siden vi da ikke spør om endelig vurdering.
+            "NEI"
+        } else {
+            null
+        }
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
@@ -2,27 +2,41 @@ package no.nav.helse.flex.medlemskap
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.flex.FellesTestOppsett
-import no.nav.helse.flex.domain.dto.*
+import no.nav.helse.flex.domain.dto.Arbeidssituasjon
+import no.nav.helse.flex.domain.dto.SoknadPeriode
+import no.nav.helse.flex.domain.dto.Soknadstype
+import no.nav.helse.flex.domain.dto.Sporsmal
+import no.nav.helse.flex.domain.dto.Svar
+import no.nav.helse.flex.domain.dto.Svartype
+import no.nav.helse.flex.domain.dto.Sykepengesoknad
+import no.nav.helse.flex.domain.dto.Visningskriterie
+import no.nav.helse.flex.medlemskap.EndeligVurderingResponse.MedlemskapVurderingStatus
 import no.nav.helse.flex.objectMapper
 import no.nav.helse.flex.serialisertTilString
+import no.nav.helse.flex.service.BEHANDLINGSTEMA_MEDLEMSKAP
+import no.nav.helse.flex.service.BEHANDLINGSTEMA_SYKEPENGER
 import no.nav.helse.flex.service.OppgaveRequest
 import no.nav.helse.flex.service.SaksbehandlingsService
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class MedlemskapVurderingTest : FellesTestOppsett() {
     val fnr = "12121234343"
-    val fom = LocalDate.of(2023, 9, 1)
-    val tom = LocalDate.of(2023, 9, 20)
+    val fom: LocalDate = LocalDate.of(2024, 5, 1)
+    val tom: LocalDate = LocalDate.of(2024, 5, 31)
 
     @Autowired
     lateinit var saksbehandlingsService: SaksbehandlingsService
@@ -33,13 +47,34 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
     }
 
     @AfterEach
-    fun opprydding() {
+    fun slettFraDatabase() {
         innsendingRepository.deleteAll()
         medlemskapVurderingRepository.deleteAll()
     }
 
     @Test
-    fun `Frilansersøknad blir ikke vurdert`() {
+    fun `Søknad uten inngående vurdering blir ikke vurdert`() {
+        val soknad = lagSoknad(medlemskapVurdering = null)
+
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Frilansersøknad har ikke inngående vurdering og blir ikke vurdert`() {
         val soknad =
             lagSoknad(
                 medlemskapVurdering = null,
@@ -49,309 +84,261 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
         saksbehandlingsService.behandleSoknad(soknad)
 
         medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskriftForFrilanser
+                """.trimMargin()
+        }
     }
 
     @Test
-    fun `Arbeidstakersøknad uten inngående medlemskapvurdering blir ikke vurdert`() {
-        val soknad = lagSoknad(medlemskapVurdering = null)
-
+    fun `Søknad med inngående UAVKLART med brukerspørsmål og endelig UAVKLART har UAVKLART i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
         saksbehandlingsService.behandleSoknad(soknad)
 
-        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+        mockEndeligVurderingResponse(soknad, MedlemskapVurderingStatus.UAVKLART)
+
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        hentLagretEndeligVurdering(soknad) shouldBeEqualTo "UAVKLART"
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveMedlemskapUavklartTekst
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
     }
 
     @Test
-    fun `Oppretter Gosys-oppgave for Arbeidstakere som har inngående og endelig medlemskapvurdering NEI`() {
-        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = medlemskapSporsmal())
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        val inngåendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)
-        inngåendeVurdering shouldNotBe null
-        inngåendeVurdering!!.sykepengesoknadId shouldBeEqualTo soknad.id
-        inngåendeVurdering.fnr shouldBeEqualTo soknad.fnr
-        inngåendeVurdering.fom shouldBeEqualTo soknad.fom
-        inngåendeVurdering.tom shouldBeEqualTo soknad.tom
-        inngåendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        inngåendeVurdering.vurderingId shouldBeEqualTo null
-        inngåendeVurdering.endeligVurdering shouldBeEqualTo null
-
-        val innsending = innsendingRepository.findBySykepengesoknadId(soknad.id)!!
-        innsending.sykepengesoknadId shouldBeEqualTo soknad.id
-        innsending.journalpostId shouldNotBe null
-
-        medlemskapMockWebserver.enqueue(
-            MockResponse().setBody(
-                EndeligVurderingResponse(
-                    soknad.id,
-                    "vurderingId",
-                    fnr,
-                    fom,
-                    tom,
-                    EndeligVurderingResponse.MedlemskapVurderingStatus.NEI,
-                ).serialisertTilString(),
-            ).addHeader("Content-Type", "application/json"),
-        )
-        saksbehandlingsService.opprettOppgave(soknad, innsending)
-
-        val endeligVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        endeligVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        endeligVurdering.vurderingId shouldBeEqualTo "vurderingId"
-        endeligVurdering.endeligVurdering shouldBeEqualTo "NEI"
-
-        val oppgaveRequest = oppgaveMockWebserver.takeRequest(5, TimeUnit.SECONDS)!!
-        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
-        val oppgaveRequestBody = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
-        oppgaveRequestBody.behandlingstema shouldBeEqualTo "ab0269"
-        oppgaveRequestBody.beskrivelse shouldBeEqualTo
-            """
-            Søknad om sykepenger for perioden 01.09.2023 til 20.09.2023
-
-            Periode 1:
-            01.09.2023 - 20.09.2023
-            Grad: 100
-            
-            Om bruker er medlem i folketrygden eller ikke, kunne ikke avklares automatisk.
-            Medlemskap status: NEI
-            
-            Du må se på svarene til bruker.
-            Informasjon om hva du skal gjøre finner du på Navet, se
-            https://navno.sharepoint.com/sites/fag-og-ytelser-eos-lovvalg-medlemskap/SitePages/Hvordan-vurderer-jeg-lovvalg-og-medlemskap.aspx
-            
-            Har du oppholdstillatelse fra Utlendingsdirektoratet?
-            Ja
-                Hvilken dato fikk du denne oppholdstillatelsen?
-                01.01.2023
-            
-                Er oppholdstillatelsen midlertidig eller permanent?
-                Midlertidig
-                    13.12.2022 - 02.01.2023
-            """.trimIndent()
-    }
-
-    @Test
-    fun `Oppretter Gosys-oppgave for Arbeidstakere som har inngående og endelig medlemskapvurdering UAVKLART`() {
-        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = medlemskapSporsmal())
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        val inngåendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)
-        inngåendeVurdering shouldNotBe null
-        inngåendeVurdering!!.sykepengesoknadId shouldBeEqualTo soknad.id
-        inngåendeVurdering.fnr shouldBeEqualTo soknad.fnr
-        inngåendeVurdering.fom shouldBeEqualTo soknad.fom
-        inngåendeVurdering.tom shouldBeEqualTo soknad.tom
-        inngåendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        inngåendeVurdering.vurderingId shouldBeEqualTo null
-        inngåendeVurdering.endeligVurdering shouldBeEqualTo null
-
-        val innsending = innsendingRepository.findBySykepengesoknadId(soknad.id)!!
-        innsending.sykepengesoknadId shouldBeEqualTo soknad.id
-        innsending.journalpostId shouldNotBe null
-
-        medlemskapMockWebserver.enqueue(
-            MockResponse().setBody(
-                EndeligVurderingResponse(
-                    soknad.id,
-                    "vurderingId",
-                    fnr,
-                    fom,
-                    tom,
-                    EndeligVurderingResponse.MedlemskapVurderingStatus.UAVKLART,
-                ).serialisertTilString(),
-            ).addHeader("Content-Type", "application/json"),
-        )
-        saksbehandlingsService.opprettOppgave(soknad, innsending)
-
-        val endeligVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        endeligVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        endeligVurdering.vurderingId shouldBeEqualTo "vurderingId"
-        endeligVurdering.endeligVurdering shouldBeEqualTo "UAVKLART"
-
-        val oppgaveRequest = oppgaveMockWebserver.takeRequest(5, TimeUnit.SECONDS)!!
-        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
-        val oppgaveRequestBody = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
-        oppgaveRequestBody.behandlingstema shouldBeEqualTo "ab0269"
-        oppgaveRequestBody.beskrivelse shouldBeEqualTo
-            """
-            Søknad om sykepenger for perioden 01.09.2023 til 20.09.2023
-
-            Periode 1:
-            01.09.2023 - 20.09.2023
-            Grad: 100
-            
-            Om bruker er medlem i folketrygden eller ikke, kunne ikke avklares automatisk.
-            Medlemskap status: UAVKLART
-            
-            Du må se på svarene til bruker.
-            Informasjon om hva du skal gjøre finner du på Navet, se
-            https://navno.sharepoint.com/sites/fag-og-ytelser-eos-lovvalg-medlemskap/SitePages/Hvordan-vurderer-jeg-lovvalg-og-medlemskap.aspx
-            
-            Har du oppholdstillatelse fra Utlendingsdirektoratet?
-            Ja
-                Hvilken dato fikk du denne oppholdstillatelsen?
-                01.01.2023
-            
-                Er oppholdstillatelsen midlertidig eller permanent?
-                Midlertidig
-                    13.12.2022 - 02.01.2023
-            """.trimIndent()
-    }
-
-    @Test
-    fun `Oppretter Gosys-oppgave for Gradert Reisetilskudd som har inngående og endelig medlemskapvurdering UAVKLART`() {
+    fun `Søknad om Gradert Reisetilskudd håndteres likt Arbeidstakersøknad`() {
         val soknad =
             lagSoknad(
                 medlemskapVurdering = "UAVKLART",
                 soknadstype = Soknadstype.GRADERT_REISETILSKUDD,
-            ).copy(sporsmal = medlemskapSporsmal())
+            ).copy(sporsmal = lagSporsmalOmOppholdstillatelse())
 
         saksbehandlingsService.behandleSoknad(soknad)
 
-        val inngåendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)
-        inngåendeVurdering shouldNotBe null
-        inngåendeVurdering!!.sykepengesoknadId shouldBeEqualTo soknad.id
-        inngåendeVurdering.fnr shouldBeEqualTo soknad.fnr
-        inngåendeVurdering.fom shouldBeEqualTo soknad.fom
-        inngåendeVurdering.tom shouldBeEqualTo soknad.tom
-        inngåendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        inngåendeVurdering.vurderingId shouldBeEqualTo null
-        inngåendeVurdering.endeligVurdering shouldBeEqualTo null
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+        mockEndeligVurderingResponse(soknad, MedlemskapVurderingStatus.UAVKLART)
 
-        val innsending = innsendingRepository.findBySykepengesoknadId(soknad.id)!!
-        innsending.sykepengesoknadId shouldBeEqualTo soknad.id
-        innsending.journalpostId shouldNotBe null
+        opprettOppgaveOgValiderLovMeRequest(soknad)
 
+        hentLagretEndeligVurdering(soknad) shouldBeEqualTo "UAVKLART"
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskriftMedReisetilskudd
+                |$oppgaveMedlemskapUavklartTekst
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående UAVKLART med brukerspørsmål men LovMe svar har tom body har UAVKLART i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+        medlemskapMockWebserver.enqueue(MockResponse().setResponseCode(500))
+
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        hentLagretEndeligVurdering(soknad) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveMedlemskapUavklartTekst
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående UAVKLART med brukerspørsmål men LovMe svarer ikke har UAVKLART i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
         medlemskapMockWebserver.enqueue(
-            MockResponse().setBody(
-                EndeligVurderingResponse(
-                    soknad.id,
-                    "vurderingId",
-                    fnr,
-                    fom,
-                    tom,
-                    EndeligVurderingResponse.MedlemskapVurderingStatus.UAVKLART,
-                ).serialisertTilString(),
-            ).addHeader("Content-Type", "application/json"),
+            MockResponse().addHeader("Content-Type", "application/json"),
         )
-        saksbehandlingsService.opprettOppgave(soknad, innsending)
+
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        hentLagretEndeligVurdering(soknad) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveMedlemskapUavklartTekst
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående UAVKLART med brukerspørsmål og endelig NEI har NEI i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+        mockEndeligVurderingResponse(soknad, MedlemskapVurderingStatus.NEI)
+
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        hentLagretEndeligVurdering(soknad) shouldBeEqualTo "NEI"
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveMedlemskapNeiTekst
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående NEI har ikke endelig vurdering og har NEI i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "NEI")
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "NEI"
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        hentLagretEndeligVurdering(soknad) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_MEDLEMSKAP
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveMedlemskapNeiTekst
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående UAVKLART med brukerspørsmål og endelig JA har ikke vurdering i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+        mockEndeligVurderingResponse(soknad, MedlemskapVurderingStatus.JA)
+
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        hentLagretEndeligVurdering(soknad) shouldBeEqualTo "JA"
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        // TODO: Burde denne egentlig ha medlemskapsspørsmålene med JA siden det har gått til avklart (JA)?
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                |$oppgaveSporsmal
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående UAVKLART uten brukerspørsmål har ikke endelig vurdering og vurdering i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART")
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "UAVKLART"
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        hentLagretEndeligVurdering(soknad) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad med inngående JA har ikke endelig vurdering og vurdering i Gosys-oppgave`() {
+        val soknad = lagSoknad(medlemskapVurdering = "JA")
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        hentLagretInngaendeVurdering(soknad) shouldBeEqualTo "JA"
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        hentLagretEndeligVurdering(soknad) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Alle verdier for inngaende og endeligvurdering er lagret riktig`() {
+        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        val inngaendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
+        inngaendeVurdering.sykepengesoknadId shouldBeEqualTo soknad.id
+        inngaendeVurdering.fnr shouldBeEqualTo soknad.fnr
+        inngaendeVurdering.fom shouldBeEqualTo soknad.fom
+        inngaendeVurdering.tom shouldBeEqualTo soknad.tom
+        inngaendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
+        inngaendeVurdering.vurderingId shouldBeEqualTo null
+        inngaendeVurdering.endeligVurdering shouldBeEqualTo null
+
+        mockEndeligVurderingResponse(soknad, MedlemskapVurderingStatus.UAVKLART)
+        opprettOppgaveOgValiderLovMeRequest(soknad)
+
+        oppgaveMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS)!!
 
         val endeligVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
         endeligVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
         endeligVurdering.vurderingId shouldBeEqualTo "vurderingId"
         endeligVurdering.endeligVurdering shouldBeEqualTo "UAVKLART"
-
-        val oppgaveRequest = oppgaveMockWebserver.takeRequest(5, TimeUnit.SECONDS)!!
-        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
-        val oppgaveRequestBody = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
-        oppgaveRequestBody.behandlingstema shouldBeEqualTo "ab0269"
-        oppgaveRequestBody.beskrivelse shouldBeEqualTo
-            """
-            Søknad om sykepenger med reisetilskudd for perioden 01.09.2023 til 20.09.2023
-
-            Periode 1:
-            01.09.2023 - 20.09.2023
-            Grad: 100
-            
-            Om bruker er medlem i folketrygden eller ikke, kunne ikke avklares automatisk.
-            Medlemskap status: UAVKLART
-            
-            Du må se på svarene til bruker.
-            Informasjon om hva du skal gjøre finner du på Navet, se
-            https://navno.sharepoint.com/sites/fag-og-ytelser-eos-lovvalg-medlemskap/SitePages/Hvordan-vurderer-jeg-lovvalg-og-medlemskap.aspx
-            
-            Har du oppholdstillatelse fra Utlendingsdirektoratet?
-            Ja
-                Hvilken dato fikk du denne oppholdstillatelsen?
-                01.01.2023
-            
-                Er oppholdstillatelsen midlertidig eller permanent?
-                Midlertidig
-                    13.12.2022 - 02.01.2023
-            """.trimIndent()
-    }
-
-    @Test
-    fun `Oppretter vanlig Gosys oppgave for arbeidstakersøknad med endeligvurdering JA`() {
-        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART")
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        val inngåendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        inngåendeVurdering.fom shouldBeEqualTo soknad.fom
-        inngåendeVurdering.tom shouldBeEqualTo soknad.tom
-        inngåendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-
-        val innsending = innsendingRepository.findBySykepengesoknadId(soknad.id)!!
-
-        medlemskapMockWebserver.enqueue(
-            MockResponse().setBody(
-                EndeligVurderingResponse(
-                    soknad.id,
-                    "vurderingId",
-                    fnr,
-                    fom,
-                    tom,
-                    EndeligVurderingResponse.MedlemskapVurderingStatus.JA,
-                ).serialisertTilString(),
-            ).addHeader("Content-Type", "application/json"),
-        )
-        saksbehandlingsService.opprettOppgave(soknad, innsending)
-
-        val endeligVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        endeligVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        endeligVurdering.vurderingId shouldBeEqualTo "vurderingId"
-        endeligVurdering.endeligVurdering shouldBeEqualTo "JA"
-
-        val oppgaveRequest = oppgaveMockWebserver.takeRequest(5, TimeUnit.SECONDS)!!
-        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
-        val oppgaveRequestBody = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
-        oppgaveRequestBody.behandlingstema shouldBeEqualTo "ab0061"
-        oppgaveRequestBody.beskrivelse shouldBeEqualTo
-            """
-            Søknad om sykepenger for perioden 01.09.2023 til 20.09.2023
-
-            Periode 1:
-            01.09.2023 - 20.09.2023
-            Grad: 100
-            
-            Spørsmål
-            Nei
-            """.trimIndent()
-    }
-
-    @Test
-    fun `Oppretter vanlig Gosys oppgave når LovMe ikke returnerer inngående vurdring, `() {
-        val soknad = lagSoknad(medlemskapVurdering = "UAVKLART")
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        val inngåendeVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        inngåendeVurdering.fom shouldBeEqualTo soknad.fom
-        inngåendeVurdering.tom shouldBeEqualTo soknad.tom
-        inngåendeVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-
-        val innsending = innsendingRepository.findBySykepengesoknadId(soknad.id)!!
-
-        medlemskapMockWebserver.enqueue(MockResponse().setResponseCode(404))
-        saksbehandlingsService.opprettOppgave(soknad, innsending)
-
-        val endeligVurdering = medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!
-        endeligVurdering.inngaendeVurdering shouldBeEqualTo "UAVKLART"
-        endeligVurdering.vurderingId shouldBeEqualTo null
-        endeligVurdering.endeligVurdering shouldBeEqualTo null
-
-        val oppgaveRequest = oppgaveMockWebserver.takeRequest(5, TimeUnit.SECONDS)!!
-        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
-        val oppgaveRequestBody = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
-        oppgaveRequestBody.behandlingstema shouldBeEqualTo "ab0061"
-        oppgaveRequestBody.beskrivelse shouldBeEqualTo
-            """
-            Søknad om sykepenger for perioden 01.09.2023 til 20.09.2023
-
-            Periode 1:
-            01.09.2023 - 20.09.2023
-            Grad: 100
-            
-            Spørsmål
-            Nei
-            """.trimIndent()
     }
 
     private fun lagSoknad(
@@ -364,33 +351,61 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
         opprettet = LocalDateTime.now(),
         fom = fom,
         tom = tom,
-        soknadPerioder =
-            listOf(
-                SoknadPeriode(fom, tom, 100),
-            ),
+        soknadPerioder = listOf(SoknadPeriode(fom, tom, 100)),
         soknadstype = soknadstype,
-        sporsmal =
-            listOf(
-                Sporsmal(
-                    id = UUID.randomUUID().toString(),
-                    tag = "FRISKMELDT",
-                    sporsmalstekst = "Spørsmål",
-                    svartype = Svartype.JA_NEI,
-                    svar = listOf(Svar(verdi = "NEI")),
-                ),
-            ),
+        sporsmal = emptyList(),
         egenmeldingsdagerFraSykmelding = emptyList(),
         status = "SENDT",
         sendtNav = LocalDateTime.now(),
         medlemskapVurdering = medlemskapVurdering,
     )
 
-    private fun medlemskapSporsmal() =
+    private fun hentLagretInngaendeVurdering(soknad: Sykepengesoknad) =
+        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!.inngaendeVurdering
+
+    private fun mockEndeligVurderingResponse(
+        soknad: Sykepengesoknad,
+        medlemskapVurderingStatus: MedlemskapVurderingStatus,
+    ) {
+        medlemskapMockWebserver.enqueue(
+            MockResponse().setBody(
+                lagEndeligVurderingResponse(soknad.id, medlemskapVurderingStatus),
+            ).addHeader("Content-Type", "application/json"),
+        )
+    }
+
+    private fun opprettOppgaveOgValiderLovMeRequest(soknad: Sykepengesoknad) {
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest().toString() shouldBeEqualTo "POST /flexvurdering HTTP/1.1"
+    }
+
+    private fun hentOgValiderOppgaveRequest(): RecordedRequest {
+        val oppgaveRequest = oppgaveMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS)!!
+        oppgaveRequest.requestLine shouldBeEqualTo "POST /api/v1/oppgaver HTTP/1.1"
+        return oppgaveRequest
+    }
+
+    private fun hentLagretEndeligVurdering(soknad: Sykepengesoknad) =
+        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id)!!.endeligVurdering
+
+    private fun lagEndeligVurderingResponse(
+        sykepengesoknadId: String,
+        endeligVurderingStatus: MedlemskapVurderingStatus,
+    ) = EndeligVurderingResponse(
+        sykepengesoknadId,
+        "vurderingId",
+        fnr,
+        fom,
+        tom,
+        endeligVurderingStatus,
+    ).serialisertTilString()
+
+    private fun lagSporsmalOmOppholdstillatelse() =
         listOf(
             Sporsmal(
                 id = UUID.randomUUID().toString(),
-                tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE",
-                sporsmalstekst = "Har du oppholdstillatelse fra Utlendingsdirektoratet?",
+                tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_V2",
+                sporsmalstekst = "Har Utlendingsdirektoratet gitt deg en oppholdstillatelse før 1. mai 2024?",
                 svartype = Svartype.JA_NEI,
                 svar = listOf(Svar(verdi = "JA")),
                 kriterieForVisningAvUndersporsmal = Visningskriterie.JA,
@@ -401,60 +416,89 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
                             tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_VEDTAKSDATO",
                             sporsmalstekst = "Hvilken dato fikk du denne oppholdstillatelsen?",
                             svartype = Svartype.DATO,
-                            min = "2013-10-09",
-                            max = "2023-10-09",
                             svar = listOf(Svar(verdi = "2023-01-01")),
+                            min = "2014-01-01",
+                            max = "2024-12-31",
                         ),
                         Sporsmal(
                             id = UUID.randomUUID().toString(),
-                            tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_GRUPPE",
-                            sporsmalstekst = "Er oppholdstillatelsen midlertidig eller permanent?",
-                            svartype = Svartype.RADIO_GRUPPE,
-                            svar = emptyList(),
-                            undersporsmal =
-                                listOf(
-                                    Sporsmal(
-                                        id = UUID.randomUUID().toString(),
-                                        tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_MIDLERTIDIG",
-                                        sporsmalstekst = "Midlertidig",
-                                        svartype = Svartype.RADIO,
-                                        svar = listOf(Svar(verdi = "CHECKED")),
-                                        kriterieForVisningAvUndersporsmal = Visningskriterie.CHECKED,
-                                        undersporsmal =
-                                            listOf(
-                                                Sporsmal(
-                                                    id = UUID.randomUUID().toString(),
-                                                    tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_MIDLERTIDIG_PERIODE",
-                                                    svartype = Svartype.PERIODE,
-                                                    min = "2013-10-09",
-                                                    max = "2033-10-09",
-                                                    svar = listOf(Svar(verdi = "{\"fom\":\"2022-12-13\",\"tom\":\"2023-01-02\"}")),
-                                                ),
-                                            ),
-                                    ),
-                                    Sporsmal(
-                                        id = UUID.randomUUID().toString(),
-                                        tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_PERMANENT",
-                                        sporsmalstekst = "Permanent",
-                                        svartype = Svartype.RADIO,
-                                        svar = emptyList(),
-                                        kriterieForVisningAvUndersporsmal = Visningskriterie.CHECKED,
-                                        undersporsmal =
-                                            listOf(
-                                                Sporsmal(
-                                                    id = UUID.randomUUID().toString(),
-                                                    tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_PERMANENT_DATO",
-                                                    sporsmalstekst = "Fra og med",
-                                                    svartype = Svartype.DATO,
-                                                    min = "2013-10-09",
-                                                    max = "2023-10-09",
-                                                    svar = emptyList(),
-                                                ),
-                                            ),
-                                    ),
-                                ),
+                            tag = "MEDLEMSKAP_OPPHOLDSTILLATELSE_PERIODE",
+                            sporsmalstekst = "Hvilken periode gjelder denne oppholdstillatelsen?",
+                            svar = listOf(Svar(verdi = "{\"fom\":\"2023-01-01\",\"tom\":\"2023-12-31\"}")),
+                            svartype = Svartype.PERIODE,
+                            min = "2014-01-01",
+                            max = "2024-12-31",
                         ),
                     ),
             ),
         )
+
+    private fun behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest: RecordedRequest): Pair<String, String> {
+        val oppgaveRequestData = objectMapper.readValue<OppgaveRequest>(oppgaveRequest.body.readUtf8())
+        return Pair(oppgaveRequestData.behandlingstema!!, oppgaveRequestData.beskrivelse)
+    }
+
+    val oppgaveOverskrift =
+        """
+        Søknad om sykepenger for perioden 01.05.2024 til 31.05.2024
+        
+        Periode 1:
+        01.05.2024 - 31.05.2024
+        Grad: 100
+        
+        """.trimIndent()
+
+    val oppgaveOverskriftForFrilanser =
+        """
+        Søknad om sykepenger for frilanser for perioden 01.05.2024 til 31.05.2024
+        
+        Periode 1:
+        01.05.2024 - 31.05.2024
+        Grad: 100
+        
+        """.trimIndent()
+
+    val oppgaveOverskriftMedReisetilskudd =
+        """
+        Søknad om sykepenger med reisetilskudd for perioden 01.05.2024 til 31.05.2024
+        
+        Periode 1:
+        01.05.2024 - 31.05.2024
+        Grad: 100
+        
+        """.trimIndent()
+
+    val oppgaveMedlemskapUavklartTekst =
+        """
+        Om bruker er medlem i folketrygden eller ikke, kunne ikke avklares automatisk.
+        Medlemskap status: UAVKLART
+        
+        Du må se på svarene til bruker.
+        Informasjon om hva du skal gjøre finner du på Navet, se
+        https://navno.sharepoint.com/sites/fag-og-ytelser-eos-lovvalg-medlemskap/SitePages/Hvordan-vurderer-jeg-lovvalg-og-medlemskap.aspx
+        
+        """.trimIndent()
+
+    val oppgaveMedlemskapNeiTekst =
+        """ 
+        Om bruker er medlem i folketrygden eller ikke er automatisk avklart.
+        Medlemskap status: NEI
+
+        Se på medlemskapsfanen i Gosys for å finne riktig periode.
+        Se på dokumentet i Gosys for å finne arbeidsgiver.
+        Se i Aa-registeret om bruker har samme arbeidsgiver som i vedtaket/A1 fra utlandet.
+        Hvis Ja: Bruker er ikke medlem. Hvis Nei: Kontakt bruker/arbeidsgiver for å avklare brukers situasjon.
+        
+        """.trimIndent()
+
+    val oppgaveSporsmal =
+        """
+        Har Utlendingsdirektoratet gitt deg en oppholdstillatelse før 1. mai 2024?
+        Ja
+            Hvilken dato fikk du denne oppholdstillatelsen?
+            01.01.2023
+        
+            Hvilken periode gjelder denne oppholdstillatelsen?
+            01.01.2023 - 31.12.2023
+        """.trimIndent()
 }

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
@@ -215,13 +215,11 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
         hentLagretEndeligVurdering(soknad) shouldBeEqualTo "JA"
 
         val oppgaveRequest = hentOgValiderOppgaveRequest()
-        // TODO: Burde denne egentlig ha medlemskapsspørsmålene med JA siden det har gått til avklart (JA)?
         behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
             behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
             beskrivelse shouldBeEqualTo
                 """
                 |$oppgaveOverskrift
-                |$oppgaveSporsmal
                 """.trimMargin()
         }
     }

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingTest.kt
@@ -53,52 +53,6 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
     }
 
     @Test
-    fun `Søknad uten inngående vurdering blir ikke vurdert`() {
-        val soknad = lagSoknad(medlemskapVurdering = null)
-
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
-
-        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
-        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
-
-        val oppgaveRequest = hentOgValiderOppgaveRequest()
-        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
-            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
-            beskrivelse shouldBeEqualTo
-                """
-                |$oppgaveOverskrift
-                """.trimMargin()
-        }
-    }
-
-    @Test
-    fun `Frilansersøknad har ikke inngående vurdering og blir ikke vurdert`() {
-        val soknad =
-            lagSoknad(
-                medlemskapVurdering = null,
-                soknadstype = Soknadstype.SELVSTENDIGE_OG_FRILANSERE,
-            ).copy(arbeidssituasjon = Arbeidssituasjon.FRILANSER)
-
-        saksbehandlingsService.behandleSoknad(soknad)
-
-        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
-
-        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
-        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
-
-        val oppgaveRequest = hentOgValiderOppgaveRequest()
-        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
-            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
-            beskrivelse shouldBeEqualTo
-                """
-                |$oppgaveOverskriftForFrilanser
-                """.trimMargin()
-        }
-    }
-
-    @Test
     fun `Søknad med inngående UAVKLART med brukerspørsmål og endelig UAVKLART har UAVKLART i Gosys-oppgave`() {
         val soknad = lagSoknad(medlemskapVurdering = "UAVKLART").copy(sporsmal = lagSporsmalOmOppholdstillatelse())
         saksbehandlingsService.behandleSoknad(soknad)
@@ -312,6 +266,52 @@ class MedlemskapVurderingTest : FellesTestOppsett() {
             beskrivelse shouldBeEqualTo
                 """
                 |$oppgaveOverskrift
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Søknad uten inngående vurdering blir ikke vurdert`() {
+        val soknad = lagSoknad(medlemskapVurdering = null)
+
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskrift
+                """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `Frilansersøknad har ikke inngående vurdering og blir ikke vurdert`() {
+        val soknad =
+            lagSoknad(
+                medlemskapVurdering = null,
+                soknadstype = Soknadstype.SELVSTENDIGE_OG_FRILANSERE,
+            ).copy(arbeidssituasjon = Arbeidssituasjon.FRILANSER)
+
+        saksbehandlingsService.behandleSoknad(soknad)
+
+        medlemskapVurderingRepository.findBySykepengesoknadId(soknad.id) shouldBeEqualTo null
+
+        saksbehandlingsService.opprettOppgave(soknad, innsendingRepository.findBySykepengesoknadId(soknad.id)!!)
+        medlemskapMockWebserver.takeRequest(100, TimeUnit.MILLISECONDS) shouldBe null
+
+        val oppgaveRequest = hentOgValiderOppgaveRequest()
+        behandlingsteamOgBeskrivelseFraOppgaveRequest(oppgaveRequest).let { (behandlingstema, beskrivelse) ->
+            behandlingstema shouldBeEqualTo BEHANDLINGSTEMA_SYKEPENGER
+            beskrivelse shouldBeEqualTo
+                """
+                |$oppgaveOverskriftForFrilanser
                 """.trimMargin()
         }
     }


### PR DESCRIPTION
Frem til nå har vi sjekket endelig vurdering på medlemskap for alle søknader. Det har resultert i at vi har laget Gosys-oppgaver merket med medlemskap i tilfeller hvor inngående vurdering var JA (avklart), men av en eller annen grunn fikk endelig vurdering UAVKLART, selv om. bruker ikke har svart på spørsmål. Det er ikke nødvendigvis feil, men skaper unødvendig støy så lenge ikke alle regler er implementert på LovMe sin side.

Følgende er avklart: 

| Inngående Vurdering           | Endelig Vurdering           | Gosys-oppgave                     |
|-------------------------------|-----------------------------|-----------------------------------|
| UAVKLART (brukerspørsmål)     | UAVKLART                    | UAVKLART (uavklart-tekst)(svar)   |
| UAVKLART (brukerspørsmål)     | null (feil fra LovMe)       | UAVKLART (uavklart-tekst)(svar)   |
| UAVKLART (brukerspørsmål)     | NEI                         | NEI (nei-tekst)(svar)             |
| NEI                           | null (sjekker ikke)         | NEI (nei-tekst)                   |
| UAVKLART (brukerspørsmål)     | JA                          | null (ingen informasjon)          |
| UAVKLART                      | null (sjekker ikke)         | null (ingen informasjon)          |
| JA                            | null (sjekker ikke)         | null (ingen informasjon)          |