### PR TITLE
Korriger url for kall til logiskVedlegg på dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
@@ -56,7 +56,7 @@ class DokArkivClient(
         dokumentId: String,
     ): LogiskVedleggResponse {
         try {
-            val url = "$dokarkivUrl/rest/journalpostapi/v1/dokumentInfo/$dokumentId/logiskVedlegg/"
+            val url = "$dokarkivUrl/rest/journalpostapi/v1/dokumentInfo/$dokumentId/logiskVedlegg"
 
             val headers = HttpHeaders()
             headers.contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/no/nav/helse/flex/mockdispatcher/DokArkivMockDispatcher.kt
+++ b/src/test/kotlin/no/nav/helse/flex/mockdispatcher/DokArkivMockDispatcher.kt
@@ -24,7 +24,7 @@ object DokArkivMockDispatcher : QueueDispatcher() {
                 ).addHeader("Content-Type", "application/json")
         }
 
-        if (request.requestUrl?.encodedPath?.endsWith("/logiskVedlegg/") == true) {
+        if (request.requestUrl?.encodedPath?.endsWith("/logiskVedlegg") == true) {
             return MockResponse()
                 .setBody(
                     LogiskVedleggResponse(

--- a/src/test/kotlin/no/nav/helse/flex/service/SaksbehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/service/SaksbehandlingIntegrationTest.kt
@@ -364,7 +364,7 @@ class SaksbehandlingIntegrationTest : FellesTestOppsett() {
             "Søknad om enkeltstående behandlingsdager for arbeidsledig for perioden 02.10.2023 til 15.10.2023"
 
         val dokArkivLogiskVedleggRequest = dokArkivMockWebserver.takeRequest(1, TimeUnit.SECONDS)!!
-        dokArkivLogiskVedleggRequest.requestLine shouldBeEqualTo "POST /rest/journalpostapi/v1/dokumentInfo/123456/logiskVedlegg/ HTTP/1.1"
+        dokArkivLogiskVedleggRequest.requestLine shouldBeEqualTo "POST /rest/journalpostapi/v1/dokumentInfo/123456/logiskVedlegg HTTP/1.1"
 
         val dokArkivLogiskVedleggRequestBody =
             objectMapper.readValue<LogiskVedleggRequest>(dokArkivLogiskVedleggRequest.body.readUtf8())


### PR DESCRIPTION
Dokarkiv vil snart ikke godta URL-er med trailing slash, derfor må dette endres
